### PR TITLE
F_method to Method

### DIFF
--- a/R/FormatInput_Fn.R
+++ b/R/FormatInput_Fn.R
@@ -22,7 +22,7 @@ function( Method, M_prior, h_prior, D_prior, SigmaR_prior, Sslope_prior=c(-999,9
 
   # Compile TMB inputs -- Data
   CatchCV = 0.01
-  Data = list("Nyears"=Nyears, "AgeMax"=AgeMax, "F_method"=F_method, "CatchCV"=CatchCV, "ln_R0_prior"=ln_R0_prior, "M_prior"=M_prior, "h_prior"=h_prior, 
+  Data = list("Nyears"=Nyears, "AgeMax"=AgeMax, "Method"=Method, "CatchCV"=CatchCV, "ln_R0_prior"=ln_R0_prior, "M_prior"=M_prior, "h_prior"=h_prior, 
             "S50_prior"=S50_prior, "Sslope_prior"=Sslope_prior, "F_t_prior"=F_t_prior, "D_prior"=D_prior, "SigmaR_prior"=SigmaR_prior, 
             "RecDev_prior"=RecDev_prior, "RecDev_biasadj"=RecDev_biasadj, "Cw_t"=Cw_t, "W_a"=W_a, "Mat_a"=Mat_a, "AgeComp_at"=AgeComp_at, "Index_t"=Index_t)
 


### PR DESCRIPTION
Hi Jim, 

F_method in used when simulating data in your example. 

> F_method = switch(Method, "CC"=-1, "CCSRA"=1, "SRA"=1, "AS"=1) # 1: Explicit F; 2: Hybrid (not implemented).  

I think in this function, it should be Method, not F_method
